### PR TITLE
Get the awsKeys from the config if they're available

### DIFF
--- a/app/conf/Config.scala
+++ b/app/conf/Config.scala
@@ -3,6 +3,7 @@ package conf
 import data.ConfigTable
 import play.api.Play.current
 import play.api.Play.{configuration => config}
+import com.amazonaws.auth.BasicAWSCredentials
 
 object Config {
   object dynamodb {
@@ -20,5 +21,21 @@ object Config {
     lazy val bucket = ConfigTable.get("deployment.bucket")
     lazy val accessKeyId = ConfigTable.get("deployment.access_key_id")
     lazy val secretAccessKey = ConfigTable.get("deployment.secret_access_key")
+  }
+
+  object awsKeys {
+    case class AWSCredentials(accessKey:String)(val secretKey:String) {
+      lazy val awsApiCreds = new BasicAWSCredentials(accessKey, secretKey)
+    }
+    object AWSCredentials {
+      def apply(accessKey: Option[String], secretKey: Option[String]): Option[AWSCredentials] = for {
+        ak <- accessKey
+        sk <- secretKey
+      } yield AWSCredentials(ak)(sk)
+    }
+
+    val accessKey: Option[String] = config.getString("AWS_ACCESS_KEY")
+    val secretKey: Option[String] = config.getString("AWS_SECRET_KEY")
+    val creds = AWSCredentials(accessKey, secretKey)
   }
 }

--- a/app/data/package.scala
+++ b/app/data/package.scala
@@ -6,10 +6,14 @@ import org.joda.time.DateTime
 import play.api.libs.json.{Format, Json}
 
 import scala.util.Try
-
+import conf.Config
 package object data extends Logging {
-  val dynamoDbClient: AmazonDynamoDBAsyncClient =
-    new AmazonDynamoDBAsyncClient().withRegion(Regions.EU_WEST_1)
+    val dynamoDbClient: AmazonDynamoDBAsyncClient =
+    Config.awsKeys.creds.map { c =>
+      new AmazonDynamoDBAsyncClient(c.awsApiCreds).withRegion(Regions.EU_WEST_1)
+    } getOrElse {
+      new AmazonDynamoDBAsyncClient().withRegion(Regions.EU_WEST_1)
+    }
 
   implicit class RichAttributeMap(map: Map[String, AttributeValue]) {
     def getString(k: String): Option[String] =


### PR DESCRIPTION
Couldn't get the dymano db client to use my default credentials so I added the option for them to be explicit in the conf file, if they're absent it will just use the default provider chain.
