### PR TITLE
Update the pandomain library and the cloudformation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
   cache,
   ws,
   "com.amazonaws" % "aws-java-sdk" % "1.9.32",
-  "com.gu" %% "pan-domain-auth-play" % "0.2.6",
+  "com.gu" %% "pan-domain-auth-play" % "0.2.7",
   "org.clapper" %% "grizzled-slf4j" % "1.0.2"
 )
 

--- a/cloudformation/quiz-builder.json
+++ b/cloudformation/quiz-builder.json
@@ -41,7 +41,7 @@
     "SSLCertificateId": {
       "Environment": {
         "CODE": "arn:aws:iam::743583969668:server-certificate/sites.code.dev-gutools.co.uk-exp2023-08-15",
-        "PROD": "arn:aws:iam::743583969668:server-certificate/sites.gutools.co.uk-exp2015-10-20"
+        "PROD": "arn:aws:iam::743583969668:server-certificate/star.gutools.co.uk-exp2018-11-17"
       }
     },
       "EnvironmentMap": {
@@ -84,6 +84,22 @@
         "Path": "/"
       }
     },
+      "PanDomainPolicy": {
+            "Type": "AWS::IAM::Policy",
+            "Properties": {
+                "PolicyName": "PanDomainPolicy",
+                "PolicyDocument": {
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Action": ["s3:GetObject"],
+                            "Resource": ["arn:aws:s3:::pan-domain-auth-settings/*"]
+                        }
+                    ]
+                },
+                "Roles": [{"Ref": "QuizBuilderRole"}]
+            }
+        },
       "DynamoDBTablePolicy": {
           "Type": "AWS::IAM::Policy",
           "Properties": {


### PR DESCRIPTION
We saw an issue on Friday with the old tool not working when you switched to different gutools products so this updates the pandomain play library used and also the cloudformation - which was out of date so broken the app once it was deployed.

\cc @chrisfinch 
